### PR TITLE
Fix missing community.docker with ansible 8.3.0

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - debian12
         include:
           - ansible: latest
-            pip3deps: 'ansible molecule "molecule-plugins[docker]" docker yamllint ansible-lint "requests<2.29" "urllib3<2"'
+            pip3deps: 'ansible molecule "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
           - ansible: pinned
             pip3deps: '"ansible==7.4.0" "molecule[docker,lint]==3.5.2" "yamllint==1.26.0" "ansible-lint==6.4.0" "requests<2.29" "urllib3<2"'
           - ansible: legacy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - debian12
         include:
           - ansible: latest
-            pip3deps: 'ansible molecule "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
+            pip3deps: 'ansible molecule "molecule-plugins[docker]" docker yamllint ansible-lint "requests<2.29" "urllib3<2"'
           - ansible: pinned
             pip3deps: '"ansible==7.4.0" "molecule[docker,lint]==3.5.2" "yamllint==1.26.0" "ansible-lint==6.4.0" "requests<2.29" "urllib3<2"'
           - ansible: legacy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - debian12
         include:
           - ansible: latest
-            pip3deps: 'ansible molecule "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
+            pip3deps: 'ansible molecule==5.1.0 "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
           - ansible: pinned
             pip3deps: '"ansible==7.4.0" "molecule[docker,lint]==3.5.2" "yamllint==1.26.0" "ansible-lint==6.4.0" "requests<2.29" "urllib3<2"'
           - ansible: legacy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - debian12
         include:
           - ansible: latest
-            pip3deps: 'ansible molecule==5.1.0 "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
+            pip3deps: 'ansible==8.2.0 ansible-core==2.15.2 molecule==5.1.0 "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
           - ansible: pinned
             pip3deps: '"ansible==7.4.0" "molecule[docker,lint]==3.5.2" "yamllint==1.26.0" "ansible-lint==6.4.0" "requests<2.29" "urllib3<2"'
           - ansible: legacy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,7 +21,7 @@ jobs:
           - debian12
         include:
           - ansible: latest
-            pip3deps: 'ansible==8.2.0 ansible-core==2.15.2 molecule==5.1.0 "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
+            pip3deps: 'ansible==8.2.0 ansible-core==2.15.2 molecule "molecule-plugins[docker]" yamllint ansible-lint "requests<2.29" "urllib3<2"'
           - ansible: pinned
             pip3deps: '"ansible==7.4.0" "molecule[docker,lint]==3.5.2" "yamllint==1.26.0" "ansible-lint==6.4.0" "requests<2.29" "urllib3<2"'
           - ansible: legacy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ${{ matrix.pip3deps }}
 
+      - name: Install collections required on ansible latest
+        run: ansible-galaxy collection install community.docker
+        if: ${{ matrix.ansible == 'latest' }}
+
       - name: run molecule tests
         run: molecule test
         working-directory: zerwes.gitremembrall

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -40,10 +40,6 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ${{ matrix.pip3deps }}
 
-      - name: Install collections required on ansible latest
-        run: ansible-galaxy collection install community.docker
-        if: ${{ matrix.ansible == 'latest' }}
-
       - name: run molecule tests
         run: molecule test
         working-directory: zerwes.gitremembrall


### PR DESCRIPTION
error: missing community.docker with:
 * ansible 8.3.0
 * ansible_core 2.15.3
 * molecule: 6.0.1

caused by: ansible/molecule#4017

interim fix:
pin ansible version : `ansible==8.2.0 ansible-core==2.15.2`
wich means *ansible latest* test is not really *ansible latest* anymore ...